### PR TITLE
Fix palette memoization

### DIFF
--- a/src/app/designer/page.tsx
+++ b/src/app/designer/page.tsx
@@ -58,12 +58,14 @@ const DesignerPageContent: React.FC = () => {
   const activeTimerTimeouts = useRef<{compId: string, timerId: NodeJS.Timeout}[]>([]);
   const [pressedComponentId, setPressedComponentId] = useState<string | null>(null);
 
-  const filteredPaletteComponents = MOCK_PALETTE_COMPONENTS.filter(comp => {
-    if (projectType === "Installationsschaltplan") {
-      return comp.category === "Installationselemente" || comp.category === "Energieversorgung";
-    }
-    return comp.category?.includes("Steuerstrom") || comp.category === "Energieversorgung" || comp.category === "Befehlsgeräte" || comp.category === "Speichernde / Verarbeitende" || comp.category === "Stellglieder";
-  });
+  const filteredPaletteComponents = React.useMemo(() => {
+    return MOCK_PALETTE_COMPONENTS.filter(comp => {
+      if (projectType === "Installationsschaltplan") {
+        return comp.category === "Installationselemente" || comp.category === "Energieversorgung";
+      }
+      return comp.category?.includes("Steuerstrom") || comp.category === "Energieversorgung" || comp.category === "Befehlsgeräte" || comp.category === "Speichernde / Verarbeitende" || comp.category === "Stellglieder";
+    });
+  }, [projectType]);
 
   const runSimulationStep = useCallback(() => {
     let newSimCompStates = JSON.parse(JSON.stringify(simulatedComponentStates));


### PR DESCRIPTION
## Summary
- fix infinite update loop by memoizing filtered palette components

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68741816685c83278d6beb6a016a7eca