### PR TITLE
Fix infinite state update loop in simulation

### DIFF
--- a/src/app/designer/page.tsx
+++ b/src/app/designer/page.tsx
@@ -167,7 +167,7 @@ const DesignerPageContent: React.FC = () => {
     if (isSimulating) {
       runSimulationStep();
     }
-  }, [isSimulating, runSimulationStep, simulatedComponentStates]);
+  }, [isSimulating, runSimulationStep]);
 
   const getAbsolutePinCoordinates = useCallback((componentId: string, pinName: string): Point | null => {
     const component = components.find(c => c.id === componentId);

--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -171,7 +171,7 @@ const DesignerPageContent: React.FC = () => {
     if (isSimulating) {
       runSimulationStep();
     }
-  }, [isSimulating, components, connections, runSimulationStep, simulatedComponentStates]);
+  }, [isSimulating, components, connections, runSimulationStep]);
 
   const getAbsolutePinCoordinates = useCallback((componentId: string, pinName: string): Point | null => {
     const component = components.find(c => c.id === componentId);


### PR DESCRIPTION
## Summary
- stop simulation effect from depending on state updates

## Testing
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6874263e6c20832793094a8f70fc7249