### PR TITLE
Add simulation control panel and dynamic switch visuals

### DIFF
--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -199,10 +199,11 @@ const DesignerPageContent: React.FC = () => {
                     currentContactState: { ...(simConfig.outputPinStateOnDeEnergized || simConfig.initialContactState || {}) }
                 }
             }));
+            runSimulationStep();
         }
         setPressedComponentId(null);
     }
-  }, [pressedComponentId, components]); 
+  }, [pressedComponentId, components, runSimulationStep]);
 
 
   const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) => {
@@ -425,6 +426,7 @@ const DesignerPageContent: React.FC = () => {
                 const newCompState = { ...prev, [id]: { ...currentSimState, currentContactState: newPinStates } };
                 return newCompState;
             });
+            runSimulationStep();
         }
         return;
     }
@@ -505,6 +507,7 @@ const DesignerPageContent: React.FC = () => {
             };
             return newCompState;
         });
+        runSimulationStep();
     }
   };
 

--- a/src/components/sidebars/PropertiesSidebar.tsx
+++ b/src/components/sidebars/PropertiesSidebar.tsx
@@ -9,6 +9,7 @@ import { Slider } from "@/components/ui/slider";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ElectricalComponent, PaletteComponentFirebaseData, Connection, ProjectType } from '@/types/circuit';
 import { COMPONENT_DEFINITIONS } from '@/config/component-definitions';
+import { getPaletteComponentById } from '@/config/mock-palette-data';
 
 interface PropertiesSidebarProps {
   component: ElectricalComponent | null;
@@ -140,7 +141,7 @@ const PropertiesSidebar: React.FC<PropertiesSidebarProps> = ({
   };
 
 
-  if (!component && !connection) return null;
+  if (!component && !connection && !isSimulating) return null;
 
   const canEditPins = component && paletteComponent && paletteComponent.hasEditablePins;
   const pinKeysToEdit = component && paletteComponent ? Object.keys(paletteComponent.initialPinLabels || {}) : [];
@@ -153,6 +154,39 @@ const PropertiesSidebar: React.FC<PropertiesSidebarProps> = ({
   const endPinDef = endComponent ? COMPONENT_DEFINITIONS[endComponent.type]?.pins[connection!.endPinName] : null;
 
   const isInstallationPlan = projectType === "Installationsschaltplan";
+
+  if (isSimulating) {
+    const interactableComponents = allComponents.filter(c => {
+      const palette = getPaletteComponentById(c.firebaseComponentId);
+      return palette?.simulation?.interactable;
+    });
+
+    return (
+      <div className="h-full w-full bg-card p-4 flex flex-col rounded-lg shadow-md">
+        <ScrollArea className="flex-grow">
+          <div className="flex justify-between items-center mb-6">
+            <h2 className="text-xl font-semibold text-card-foreground">Simulationssteuerung</h2>
+            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close sidebar">
+              <X className="h-5 w-5" />
+            </Button>
+          </div>
+          <div className="space-y-4">
+            {interactableComponents.map(comp => (
+              <div key={comp.id} className="flex items-center justify-between">
+                <span className="text-sm text-card-foreground">{comp.label}</span>
+                <Button variant="outline" size="sm" onClick={() => onComponentClick(comp.id)}>
+                  Betätigen
+                </Button>
+              </div>
+            ))}
+            {interactableComponents.length === 0 && (
+              <p className="text-sm text-muted-foreground">Keine bedienbaren Bauteile vorhanden.</p>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full w-full bg-card p-4 flex flex-col rounded-lg shadow-md">

--- a/src/config/component-definitions.tsx
+++ b/src/config/component-definitions.tsx
@@ -33,15 +33,15 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
     width: 80,
     height: 60,
     render: (label, _state, displayPinLabels = { '13': '13', '14': '14' }, simulatedState) => {
-        const isClosed = simulatedState?.currentContactState?.['13'] === 'closed' && simulatedState?.currentContactState?.['14'] === 'closed';
+        const isClosed = simulatedState?.currentContactState?.['13'] === 'closed';
         return (
             <>
                 <line x1="25" y1="0" x2="25" y2="22.5" className="line" />
                 <line x1="25" y1="37.5" x2="25" y2="60" className="line" />
                 {isClosed ? (
-                    <line x1="25" y1="22.5" x2="25" y2="37.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-200" />
+                    <line x1="25" y1="22.5" x2="25" y2="37.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-100" />
                 ) : (
-                    <line x1="15" y1="22.5" x2="25" y2="37.5" className="line transition-all duration-200" />
+                    <line x1="15" y1="22.5" x2="25" y2="37.5" className="line transition-all duration-100" />
                 )}
                 <text x="15" y="18" className="text-pin">{displayPinLabels['13']}</text>
                 <text x="15" y="48" className="text-pin">{displayPinLabels['14']}</text>
@@ -59,18 +59,18 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
     width: 80,
     height: 60,
     render: (label, _state, displayPinLabels = { '11': '11', '12': '12' }, simulatedState) => {
-        const isClosed = simulatedState?.currentContactState?.['11'] === 'closed' && simulatedState?.currentContactState?.['12'] === 'closed';
+        const isClosed = simulatedState?.currentContactState?.['11'] === 'closed';
         return (
             <>
                 <line x1="25" y1="0" x2="25" y2="22.5" className="line" />
                 <line x1="25" y1="37.5" x2="25" y2="60" className="line" />
                 {isClosed ? (
                     <>
-                        <line x1="25" y1="22.5" x2="30" y2="22.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-200" />
-                        <line x1="30" y1="22.5" x2="25" y2="37.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-200" />
+                        <line x1="25" y1="22.5" x2="30" y2="22.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-100" />
+                        <line x1="30" y1="22.5" x2="25" y2="37.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-100" />
                     </>
                 ) : (
-                     <line x1="25" y1="22.5" x2="25" y2="37.5" className="line transition-all duration-200" /> // Represents open for simulation
+                     <line x1="25" y1="22.5" x2="25" y2="37.5" className="line transition-all duration-100" />
                 )}
                 <text x="15" y="18" className="text-pin">{displayPinLabels['11']}</text>
                 <text x="15" y="48" className="text-pin">{displayPinLabels['12']}</text>


### PR DESCRIPTION
## Summary
- add central "Simulationssteuerung" panel in `PropertiesSidebar`
- render interactable components with button to trigger them
- update Schließer and Öffner visuals to react to simulated state
- invoke `runSimulationStep` after interactive state changes for instant feedback

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68748bb0ef248327968f6ca5a6da7853