### PR TITLE
Fix simulation update loop

### DIFF
--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -157,9 +157,17 @@ const DesignerPageContent: React.FC = () => {
         return acc;
       }, {} as { [key: string]: SimulatedConnectionState });
 
-      setSimulatedConnectionStates(newConnStates);
+      setSimulatedConnectionStates(currentConnStates => {
+        if (JSON.stringify(newConnStates) !== JSON.stringify(currentConnStates)) {
+          return newConnStates;
+        }
+        return currentConnStates;
+      });
 
-      return newSimCompStates;
+      if (JSON.stringify(newSimCompStates) !== JSON.stringify(currentSimStates)) {
+        return newSimCompStates;
+      }
+      return currentSimStates;
     });
   }, [components, connections]);
 
@@ -200,11 +208,10 @@ const DesignerPageContent: React.FC = () => {
                     currentContactState: { ...(simConfig.outputPinStateOnDeEnergized || simConfig.initialContactState || {}) }
                 }
             }));
-            runSimulationStep();
         }
         setPressedComponentId(null);
     }
-  }, [pressedComponentId, components, runSimulationStep]);
+  }, [pressedComponentId, components]);
 
 
   const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) => {


### PR DESCRIPTION
## Summary
- prevent infinite rerendering in runSimulationStep by only updating states when values change
- remove manual runSimulationStep call from mouse-up handler

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687493ced0b4832789f308dcd0a4dfb7