### PR TITLE
Improve UI snap lines and supply placement

### DIFF
--- a/src/components/canvas/CircuitCanvas.tsx
+++ b/src/components/canvas/CircuitCanvas.tsx
@@ -23,6 +23,7 @@ interface CircuitCanvasProps {
   simulatedComponentStates: { [key: string]: SimulatedComponentState };
   selectedConnectionId?: string | null;
   projectType?: ProjectType | null;
+  snapLines?: { x: number | null; y: number | null };
 }
 
 const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
@@ -45,7 +46,8 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
   simulatedConnectionStates,
   simulatedComponentStates,
   selectedConnectionId,
-  projectType
+  projectType,
+  snapLines
 }) => {
 
   const getLineColor = (connection: Connection, isConducting: boolean) => {
@@ -172,6 +174,27 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
           y2={currentMouseSvgCoords.y}
           className="line stroke-[hsl(var(--ring))] stroke-2"
           strokeDasharray="5,5"
+        />
+      )}
+
+      {snapLines && snapLines.x !== null && (
+        <line
+          x1={snapLines.x}
+          y1={0}
+          x2={snapLines.x}
+          y2={height}
+          stroke="hsl(var(--muted-foreground))"
+          strokeDasharray="4 2"
+        />
+      )}
+      {snapLines && snapLines.y !== null && (
+        <line
+          x1={0}
+          y1={snapLines.y}
+          x2={width}
+          y2={snapLines.y}
+          stroke="hsl(var(--muted-foreground))"
+          strokeDasharray="4 2"
         />
       )}
     </svg>


### PR DESCRIPTION
## Summary
- automatically place first 24V/0V sources when creating Steuerstromkreis projects
- implement snap line logic while dragging components
- draw temporary snap lines in `CircuitCanvas`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687b2c4ce6ec83279287953c572cc532