### PR TITLE
Fix opener symbol and restore project type dialog

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,22 @@
 "use client";
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ListChecks, Settings, BookOpen, LogIn, PlusCircle } from 'lucide-react';
+import NewProjectDialog from '@/components/modals/NewProjectDialog';
 
 export default function HomePage() {
+  const router = useRouter();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleCreate = (name: string, type: string) => {
+    const url = `/new-project?projectName=${encodeURIComponent(name)}&projectType=${encodeURIComponent(type)}`;
+    router.push(url);
+  };
+
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
       <header className="absolute top-0 right-0 p-6">
@@ -25,20 +36,18 @@ export default function HomePage() {
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-4xl w-full">
-          <Link href="/new-project" passHref>
-            <Card className="hover:shadow-lg transition-shadow cursor-pointer h-full flex flex-col">
-              <CardHeader>
-                <CardTitle className="flex items-center text-2xl">
-                  <PlusCircle className="mr-3 h-8 w-8 text-primary" />
-                  Neues Projekt
-                </CardTitle>
-                <CardDescription>Starten Sie ein neues Schaltungsdesign von Grund auf.</CardDescription>
-              </CardHeader>
-              <CardContent className="flex-grow flex items-end">
-                 <Button className="w-full mt-auto">Projekt erstellen</Button>
-              </CardContent>
-            </Card>
-          </Link>
+          <Card onClick={() => setIsDialogOpen(true)} className="hover:shadow-lg transition-shadow cursor-pointer h-full flex flex-col">
+            <CardHeader>
+              <CardTitle className="flex items-center text-2xl">
+                <PlusCircle className="mr-3 h-8 w-8 text-primary" />
+                Neues Projekt
+              </CardTitle>
+              <CardDescription>Starten Sie ein neues Schaltungsdesign von Grund auf.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex-grow flex items-end">
+               <Button className="w-full mt-auto" onClick={() => setIsDialogOpen(true)}>Projekt erstellen</Button>
+            </CardContent>
+          </Card>
 
           <Card className="hover:shadow-lg transition-shadow cursor-not-allowed opacity-50 h-full flex flex-col">
             <CardHeader>
@@ -81,6 +90,12 @@ export default function HomePage() {
           </Card>
         </div>
       </main>
+
+      <NewProjectDialog
+        isOpen={isDialogOpen}
+        onClose={() => setIsDialogOpen(false)}
+        onCreate={handleCreate}
+      />
 
       <footer className="absolute bottom-0 p-6 text-center w-full">
         <p className="text-sm text-muted-foreground">

--- a/src/components/modals/NewProjectDialog.tsx
+++ b/src/components/modals/NewProjectDialog.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import type { ProjectType } from '@/types/circuit';
+import { ProjectTypes } from '@/types/circuit';
+
+interface NewProjectDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: (projectName: string, projectType: ProjectType) => void;
+}
+
+const NewProjectDialog: React.FC<NewProjectDialogProps> = ({ isOpen, onClose, onCreate }) => {
+  const [projectName, setProjectName] = useState('');
+  const [projectType, setProjectType] = useState<ProjectType>('Steuerstromkreis');
+
+  const handleCreate = () => {
+    onCreate(projectName || 'Unbenanntes Projekt', projectType);
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Neues Projekt</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="project-name" className="text-right">
+              Projektname
+            </Label>
+            <Input
+              id="project-name"
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value)}
+              className="col-span-3"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="project-type" className="text-right">
+              Projekttyp
+            </Label>
+            <Select value={projectType} onValueChange={(val) => setProjectType(val as ProjectType)}>
+              <SelectTrigger id="project-type" className="col-span-3">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ProjectTypes.map((pt) => (
+                  <SelectItem key={pt} value={pt}>
+                    {pt}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              Abbrechen
+            </Button>
+          </DialogClose>
+          <Button type="button" onClick={handleCreate}>
+            Erstellen
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NewProjectDialog;

--- a/src/config/component-definitions.tsx
+++ b/src/config/component-definitions.tsx
@@ -67,12 +67,12 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
                 <line x1="25" y1="0" x2="25" y2="22.5" className="line" />
                 <line x1="25" y1="37.5" x2="25" y2="60" className="line" />
                 {isClosed ? (
-                    <>
-                        <line x1="25" y1="22.5" x2="30" y2="22.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-100" />
-                        <line x1="30" y1="22.5" x2="25" y2="37.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-100" />
-                    </>
+                    <line x1="15" y1="22.5" x2="25" y2="37.5" className="line stroke-[hsl(var(--destructive))] stroke-2 transition-all duration-100" />
                 ) : (
-                     <line x1="25" y1="22.5" x2="25" y2="37.5" className="line transition-all duration-100" />
+                    <>
+                        <line x1="25" y1="22.5" x2="30" y2="22.5" className="line transition-all duration-100" />
+                        <line x1="30" y1="22.5" x2="25" y2="37.5" className="line transition-all duration-100" />
+                    </>
                 )}
                 <text x="15" y="18" className="text-pin">{displayPinLabels['11']}</text>
                 <text x="15" y="48" className="text-pin">{displayPinLabels['12']}</text>


### PR DESCRIPTION
## Summary
- fix rendering for Öffner contact symbol
- add new NewProjectDialog modal
- integrate project name and type selection in home page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687b2c75f8a08327b6d58ed69f3aa32a