### PR TITLE
Add installation socket, switch, and sensor components

### DIFF
--- a/src/components/circuit/PaletteIcon.tsx
+++ b/src/components/circuit/PaletteIcon.tsx
@@ -114,6 +114,36 @@ const PaletteIcon: React.FC<PaletteIconProps> = ({ type }) => {
         </>
       );
       break;
+    case 'Steckdose':
+      iconContent = (
+        <>
+          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
+          <circle cx="14" cy="16" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
+          <circle cx="26" cy="16" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
+          <circle cx="20" cy="24" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
+        </>
+      );
+      break;
+    case 'Wechselschalter':
+      iconContent = (
+        <>
+          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
+          <line x1="20" y1="8" x2="20" y2="20" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="12" y1="24" x2="28" y2="24" stroke={symbolStrokeColor} strokeWidth="2" />
+        </>
+      );
+      break;
+    case 'Grenztaster':
+      iconContent = (
+        <>
+          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
+          <line x1="20" y1="8" x2="20" y2="18" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="20" y1="22" x2="20" y2="32" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="14" y1="18" x2="20" y2="22" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="8" y1="6" x2="14" y2="12" stroke={symbolStrokeColor} strokeWidth="2" />
+        </>
+      );
+      break;
     default:
       iconContent = (
         <rect x="5" y="5" width="30" height="30" stroke="grey" strokeWidth="1" fill="lightgrey" />

--- a/src/config/component-definitions.tsx
+++ b/src/config/component-definitions.tsx
@@ -234,4 +234,74 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
       'N': { x: 15, y: 29, label: 'N' }
     }
   },
+  'Steckdose': {
+    width: 30,
+    height: 30,
+    render: (label) => (
+      <>
+        <circle cx="15" cy="15" r="14" className="symbol stroke-2" />
+        <circle cx="11" cy="13" r="2" stroke="hsl(var(--foreground))" strokeWidth="1.5" fill="none" />
+        <circle cx="19" cy="13" r="2" stroke="hsl(var(--foreground))" strokeWidth="1.5" fill="none" />
+        <circle cx="15" cy="18" r="2" stroke="hsl(var(--foreground))" strokeWidth="1.5" fill="none" />
+        <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
+      </>
+    ),
+    pins: {
+      'L': { x: 1, y: 15, label: 'L' },
+      'N': { x: 29, y: 15, label: 'N' },
+      'PE': { x: 15, y: 29, label: 'PE' }
+    }
+  },
+  'Wechselschalter': {
+    width: 30,
+    height: 30,
+    render: (label, _state, displayPinLabels = { 'L': 'L', 'Ausgang1': '1', 'Ausgang2': '2' }, simulatedState) => {
+      const toAusgang1 = simulatedState?.currentContactState?.Ausgang1 === 'closed';
+      const wiperX = toAusgang1 ? 8 : 22;
+      const inactiveX = toAusgang1 ? 22 : 8;
+      return (
+        <>
+          <circle cx="15" cy="15" r="14" className="symbol stroke-2" />
+          <line x1="15" y1="5" x2="15" y2="15" className="line" strokeWidth="1.5" />
+          <line x1="8" y1="22" x2="8" y2="25" className="line" strokeWidth="1.5" />
+          <line x1="22" y1="22" x2="22" y2="25" className="line" strokeWidth="1.5" />
+          <line x1="15" y1="15" x2={inactiveX} y2="22" className="line" strokeWidth="1.5" />
+          <line x1="15" y1="15" x2={wiperX} y2="22" className="line stroke-[hsl(var(--destructive))]" strokeWidth="1.5" />
+          <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
+        </>
+      );
+    },
+    pins: {
+      'L': { x: 15, y: 1, label: 'L' },
+      'Ausgang1': { x: 1, y: 25, label: '1' },
+      'Ausgang2': { x: 29, y: 25, label: '2' }
+    },
+    initialDisplayPinLabels: { 'L': 'L', 'Ausgang1': '1', 'Ausgang2': '2' }
+  },
+  'Grenztaster': {
+    width: 30,
+    height: 30,
+    render: (label, _state, displayPinLabels = { 'in': 'in', 'out': 'out' }, simulatedState) => {
+      const isClosed = simulatedState?.currentContactState?.in === 'closed';
+      return (
+        <>
+          <circle cx="15" cy="15" r="14" className="symbol stroke-2" />
+          <line x1="15" y1="5" x2="15" y2="12" className="line" strokeWidth="1.5" />
+          <line x1="15" y1="18" x2="15" y2="25" className="line" strokeWidth="1.5" />
+          {isClosed ? (
+            <line x1="15" y1="12" x2="15" y2="18" className="line stroke-[hsl(var(--destructive))]" strokeWidth="1.5" />
+          ) : (
+            <line x1="10" y1="12" x2="15" y2="18" className="line" strokeWidth="1.5" />
+          )}
+          <line x1="5" y1="3" x2="10" y2="8" className="line" strokeWidth="1.5" />
+          <line x1="7" y1="3" x2="5" y2="5" className="line" strokeWidth="1.5" />
+          <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
+        </>
+      );
+    },
+    pins: {
+      'in': { x: 15, y: 1, label: 'in' },
+      'out': { x: 15, y: 29, label: 'out' }
+    }
+  },
 };

--- a/src/config/mock-palette-data.ts
+++ b/src/config/mock-palette-data.ts
@@ -271,6 +271,72 @@ export const MOCK_PALETTE_COMPONENTS: PaletteComponentFirebaseData[] = [
       energizePins: ['L', 'N'],
     }
   },
+  {
+    id: 'steckdose_install',
+    name: 'Steckdose',
+    type: 'Steckdose',
+    abbreviation: 'SD',
+    defaultLabelPrefix: 'SD',
+    category: 'Installationselemente',
+    description: 'Schutzkontaktsteckdose.',
+    hasToggleState: false,
+    hasEditablePins: false,
+    initialPinLabels: { 'L': 'L', 'N': 'N', 'PE': 'PE' },
+    resizable: true,
+    defaultSize: { width: COMPONENT_DEFINITIONS['Steckdose']?.width || 30, height: COMPONENT_DEFINITIONS['Steckdose']?.height || 30 },
+    minScale: 0.8, maxScale: 1.5, scaleStep: 0.1,
+    simulation: {
+      interactable: false,
+      controlLogic: 'pass_through',
+      controlledBy: 'voltage',
+    }
+  },
+  {
+    id: 'wechselschalter_install',
+    name: 'Wechselschalter',
+    type: 'Wechselschalter',
+    abbreviation: 'W',
+    defaultLabelPrefix: 'W',
+    category: 'Installationselemente',
+    description: 'Schalter mit zwei Ausgängen.',
+    hasToggleState: true,
+    hasEditablePins: false,
+    initialPinLabels: { 'L': 'L', 'Ausgang1': '1', 'Ausgang2': '2' },
+    resizable: true,
+    defaultSize: { width: COMPONENT_DEFINITIONS['Wechselschalter']?.width || 30, height: COMPONENT_DEFINITIONS['Wechselschalter']?.height || 30 },
+    minScale: 0.8, maxScale: 1.5, scaleStep: 0.1,
+    simulation: {
+      interactable: true,
+      controlLogic: 'toggle_on_click',
+      controlledBy: 'user',
+      initialContactState: { 'L': 'closed', 'Ausgang1': 'closed', 'Ausgang2': 'open' },
+      outputPinStateOnEnergized: { 'L': 'closed', 'Ausgang1': 'open', 'Ausgang2': 'closed' },
+      outputPinStateOnDeEnergized: { 'L': 'closed', 'Ausgang1': 'closed', 'Ausgang2': 'open' },
+    }
+  },
+  {
+    id: 'grenztaster_sensor',
+    name: 'Grenztaster',
+    type: 'Grenztaster',
+    abbreviation: 'G',
+    defaultLabelPrefix: 'G',
+    category: 'Sensoren',
+    description: 'Mechanischer Grenztaster als Sensor.',
+    hasToggleState: true,
+    hasEditablePins: false,
+    initialPinLabels: { 'in': 'in', 'out': 'out' },
+    resizable: true,
+    defaultSize: { width: COMPONENT_DEFINITIONS['Grenztaster']?.width || 30, height: COMPONENT_DEFINITIONS['Grenztaster']?.height || 30 },
+    minScale: 0.8, maxScale: 1.5, scaleStep: 0.1,
+    simulation: {
+      interactable: true,
+      controlLogic: 'toggle_on_press',
+      controlledBy: 'user',
+      initialContactState: { 'in': 'open', 'out': 'open' },
+      outputPinStateOnEnergized: { 'in': 'closed', 'out': 'closed' },
+      outputPinStateOnDeEnergized: { 'in': 'open', 'out': 'open' },
+    }
+  },
 ];
 
 export const getPaletteComponentById = (id: string | undefined): PaletteComponentFirebaseData | undefined => {


### PR DESCRIPTION
## Summary
- add Steckdose, Wechselschalter and Grenztaster definitions
- extend palette data with new installation and sensor components
- provide icons for the new components in the palette

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687c3ecd294c8327bf73b225c5645287