### PR TITLE
Fix palette filter for new project types

### DIFF
--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -65,9 +65,27 @@ const DesignerPageContent: React.FC = () => {
   const filteredPaletteComponents = React.useMemo(() => {
     return MOCK_PALETTE_COMPONENTS.filter(comp => {
       if (projectType === "Installationsschaltplan") {
-        return comp.category === "Installationselemente" || comp.category === "Energieversorgung";
+        return (
+          comp.category === "Installationselemente" ||
+          comp.category === "Energieversorgung" ||
+          comp.category === "Sensoren"
+        );
       }
-      return comp.category?.includes("Steuerstrom") || comp.category === "Energieversorgung" || comp.category === "Befehlsgeräte" || comp.category === "Speichernde / Verarbeitende" || comp.category === "Stellglieder";
+      if (projectType === "Hauptstromkreis") {
+        return (
+          comp.category === "Hauptstromkreis" ||
+          comp.category === "Energieversorgung" ||
+          comp.category?.includes("Steuerstrom")
+        );
+      }
+      // Default for Steuerstromkreis etc.
+      return (
+        comp.category?.includes("Steuerstrom") ||
+        comp.category === "Energieversorgung" ||
+        comp.category === "Befehlsgeräte" ||
+        comp.category === "Speichernde / Verarbeitende" ||
+        comp.category === "Stellglieder"
+      );
     });
   }, [projectType]);
 


### PR DESCRIPTION
## Summary
- update palette filtering in `page.tsx` so the new categories appear

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687c4795683083279ad33caa222260a1