### PR TITLE
Add selection rectangle for moving multiple components

### DIFF
--- a/src/components/canvas/CircuitCanvas.tsx
+++ b/src/components/canvas/CircuitCanvas.tsx
@@ -26,6 +26,9 @@ interface CircuitCanvasProps {
   selectedConnectionId?: string | null;
   projectType?: ProjectType | null;
   snapLines?: { x: number | null; y: number | null };
+  onCanvasMouseDown?: (e: React.MouseEvent<SVGSVGElement>) => void;
+  selectionRect?: { x: number; y: number; width: number; height: number } | null;
+  selectedComponentIds?: string[];
 }
 
 const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
@@ -51,7 +54,10 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
   simulatedComponentStates,
   selectedConnectionId,
   projectType,
-  snapLines
+  snapLines,
+  onCanvasMouseDown,
+  selectionRect,
+  selectedComponentIds
 }) => {
 
   const getLineColor = (connection: Connection, isConducting: boolean) => {
@@ -77,6 +83,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
       className="border border-border bg-card rounded-lg shadow-inner flex-grow"
       data-testid="circuit-canvas"
       style={{ cursor: isMeasuring ? 'crosshair' : undefined }}
+      onMouseDown={onCanvasMouseDown}
     >
       {components.map(comp => (
         <DraggableComponent
@@ -90,6 +97,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
           isSimulating={isSimulating}
           isMeasuring={isMeasuring}
           simulatedState={simulatedComponentStates[comp.id]}
+          selected={selectedComponentIds?.includes(comp.id)}
         />
       ))}
 
@@ -201,6 +209,18 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
           x2={width}
           y2={snapLines.y}
           stroke="hsl(var(--muted-foreground))"
+          strokeDasharray="4 2"
+        />
+      )}
+
+      {selectionRect && (
+        <rect
+          x={selectionRect.x}
+          y={selectionRect.y}
+          width={selectionRect.width}
+          height={selectionRect.height}
+          fill="rgba(100,100,255,0.2)"
+          stroke="hsl(var(--ring))"
           strokeDasharray="4 2"
         />
       )}

--- a/src/components/circuit/DraggableComponent.tsx
+++ b/src/components/circuit/DraggableComponent.tsx
@@ -13,6 +13,7 @@ interface DraggableComponentProps {
   isSimulating?: boolean;
   isMeasuring?: boolean;
   simulatedState?: SimulatedComponentState;
+  selected?: boolean;
 }
 
 const DraggableComponent: React.FC<DraggableComponentProps> = ({
@@ -25,6 +26,7 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({
   isSimulating,
   isMeasuring,
   simulatedState,
+  selected,
 }) => {
   const definition = COMPONENT_DEFINITIONS[component.type];
   if (!definition) return null;
@@ -52,6 +54,8 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({
   };
 
   const scale = component.scale || 1;
+  const width = (component.width ?? definition.width) * scale;
+  const height = (component.height ?? definition.height) * scale;
 
   return (
     <g
@@ -71,6 +75,19 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({
         component.displayPinLabels,
         simulatedState,
         component.id
+      )}
+
+      {selected && (
+        <rect
+          x={0}
+          y={0}
+          width={width}
+          height={height}
+          fill="none"
+          stroke="hsl(var(--ring))"
+          strokeDasharray="4 2"
+          pointerEvents="none"
+        />
       )}
       
       {/* Pin circles are also drawn within this scaled group.


### PR DESCRIPTION
## Summary
- enable selection state for canvas components
- add dashed highlight around selected components
- support rectangle selection on the canvas
- allow moving all selected components together

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687c5504613483278010da5e38c4e487