### PR TITLE
Implement parent-child relation in circuit components

### DIFF
--- a/src/types/circuit.ts
+++ b/src/types/circuit.ts
@@ -67,6 +67,7 @@ export interface ElectricalComponent {
   id: string;
   type: string;
   firebaseComponentId: string; // ID from PaletteComponentFirebaseData
+  parentId?: string | null;
   x: number;
   y: number;
   label: string;


### PR DESCRIPTION
## Summary
- extend `ElectricalComponent` with optional `parentId`
- when adding a component, link contacts to coils based on matching labels
- update existing contacts when a new coil is added

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c5ee9cbf88327a65b58bfd29e6050