### PR TITLE
Implement DIN/IEC prefixes and add path numbers

### DIFF
--- a/src/components/canvas/CircuitCanvas.tsx
+++ b/src/components/canvas/CircuitCanvas.tsx
@@ -230,6 +230,20 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
           {m.value}
         </text>
       ))}
+
+      {/* Strompfad-Nummerierung am unteren Rand */}
+      {Array.from({ length: Math.floor(viewBoxWidth / 25) }, (_, i) => i + 1).map(num => (
+        <text
+          key={`path-${num}`}
+          x={num * 25 - 12.5}
+          y={viewBoxHeight - 5}
+          fontSize="10px"
+          textAnchor="middle"
+          fill="hsl(var(--muted-foreground))"
+        >
+          {num}
+        </text>
+      ))}
     </svg>
   );
 };

--- a/src/config/mock-palette-data.ts
+++ b/src/config/mock-palette-data.ts
@@ -196,7 +196,7 @@ export const MOCK_PALETTE_COMPONENTS: PaletteComponentFirebaseData[] = [
     type: 'Öffner',
     paletteIconType: 'NotAusTaster',
     abbreviation: 'S',
-    defaultLabelPrefix: 'SQ',
+    defaultLabelPrefix: 'S',
     category: 'Befehlsgeräte (Steuerstrom)',
     description: 'Sicherheitsrelevanter Öffner mit mechanischer Verriegelung.',
     hasToggleState: true,


### PR DESCRIPTION
## Summary
- update label prefix for emergency stop button using DIN/IEC letter
- render path numbering at bottom of circuit canvas

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687c5ed1fb388327a23b0c61d11a884f