### PR TITLE
Implement drag-and-drop library palette

### DIFF
--- a/DOKUMENTATION_Stromlaufplan_Modul_README.md
+++ b/DOKUMENTATION_Stromlaufplan_Modul_README.md
@@ -34,6 +34,10 @@ Dieses Repository dokumentiert die visuelle, technische und funktionale Spezifik
 - Kurzschluss-Erkennung (L direkt auf N/PE ohne Last → Fehler)
 - Fehler-Panel mit Fehlermeldungen im Klartext
 
+### Bauteil-Bibliothek
+- Linkes Flyout-Menü mit Drag-&-Drop-Unterstützung
+- Zeigt ausschließlich Bauteile des ZD-Moduls
+
 ---
 
 ## 💡 Ziel

--- a/src/app/designer/page.tsx
+++ b/src/app/designer/page.tsx
@@ -216,6 +216,21 @@ const DesignerPageContent: React.FC = () => {
     };
     setComponents(prev => [...prev, newComponent]);
   };
+
+  const addComponentAtPosition = (paletteItem: PaletteComponentFirebaseData, position: Point) => {
+    const newId = `${paletteItem.id.replace(/[^a-z0-9]/gi, '')}-${Date.now()}`;
+    const newComponent: ElectricalComponent = {
+      id: newId,
+      type: paletteItem.type,
+      firebaseComponentId: paletteItem.id,
+      x: position.x,
+      y: position.y,
+      label: `${paletteItem.defaultLabelPrefix}${components.filter(c => c.type === paletteItem.type).length + 1}`,
+      displayPinLabels: { ...(paletteItem.initialPinLabels || {}) },
+      scale: 1.0,
+    };
+    setComponents(prev => [...prev, newComponent]);
+  };
   
   // ... other handlers
   const getAbsolutePinCoordinates = () => ({x:0, y:0}); // Simplified
@@ -255,6 +270,7 @@ const DesignerPageContent: React.FC = () => {
                     simulatedComponentStates={simulatedComponentStates}
                     selectedConnectionId={selectedConnectionId}
                     projectType={projectType}
+                    onDropComponent={addComponentAtPosition}
                 />
             </div>
         </div>

--- a/src/components/canvas/CircuitCanvas.tsx
+++ b/src/components/canvas/CircuitCanvas.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import DraggableComponent from '@/components/circuit/DraggableComponent';
-import type { ElectricalComponent, Connection, Point, SimulatedConnectionState, SimulatedComponentState, ProjectType } from '@/types/circuit';
+import type { ElectricalComponent, Connection, Point, SimulatedConnectionState, SimulatedComponentState, ProjectType, PaletteComponentFirebaseData } from '@/types/circuit';
 import { renderView } from '@/lib/view-renderer';
 
 interface CircuitCanvasProps {
@@ -29,6 +29,7 @@ interface CircuitCanvasProps {
   showGrid?: boolean;
   snapLines?: { x: number | null; y: number | null };
   onCanvasMouseDown?: (e: React.MouseEvent<SVGSVGElement>) => void;
+  onDropComponent?: (component: PaletteComponentFirebaseData, position: Point) => void;
   selectionRect?: { x: number; y: number; width: number; height: number } | null;
   selectedComponentIds?: string[];
 }
@@ -59,6 +60,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
   showGrid,
   snapLines,
   onCanvasMouseDown,
+  onDropComponent,
   selectionRect,
   selectedComponentIds
 }) => {
@@ -68,6 +70,32 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
     : { components, connections };
   const viewComponents = viewData.components;
   const viewConnections = viewData.connections;
+
+  const handleDragOver = (e: React.DragEvent<SVGSVGElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent<SVGSVGElement>) => {
+    e.preventDefault();
+    if (!onDropComponent) return;
+    const data = e.dataTransfer.getData('application/json');
+    if (!data) return;
+    try {
+      const comp = JSON.parse(data) as PaletteComponentFirebaseData;
+      if (svgRef.current) {
+        const ctm = svgRef.current.getScreenCTM();
+        if (ctm) {
+          const pt = svgRef.current.createSVGPoint();
+          pt.x = e.clientX;
+          pt.y = e.clientY;
+          const local = pt.matrixTransform(ctm.inverse());
+          onDropComponent(comp, { x: local.x, y: local.y });
+        }
+      }
+    } catch (err) {
+      console.error('Failed to parse drag data', err);
+    }
+  };
 
   const getLineColor = (connection: Connection, isConducting: boolean) => {
     if (isSimulating) {
@@ -93,6 +121,8 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
       data-testid="circuit-canvas"
       style={{ cursor: isMeasuring ? 'crosshair' : undefined }}
       onMouseDown={onCanvasMouseDown}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
     >
       {showGrid && (
         <defs>

--- a/src/components/sidebars/ComponentPalette.tsx
+++ b/src/components/sidebars/ComponentPalette.tsx
@@ -60,9 +60,13 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({ onAddComponent, isO
                       <Button
                         key={componentData.id}
                         onClick={() => onAddComponent(componentData)}
-                        variant="outline" 
+                        variant="outline"
                         className="w-full h-auto p-2 bg-card hover:bg-muted focus:ring-2 focus:ring-ring focus:ring-offset-2 transition duration-150 ease-in-out shadow-md flex flex-col items-center justify-center group border-border text-left"
                         disabled={isSimulating}
+                        draggable={!isSimulating}
+                        onDragStart={(e) => {
+                          e.dataTransfer.setData('application/json', JSON.stringify(componentData));
+                        }}
                       >
                         <div className="bg-white p-1 rounded mb-1.5 inline-block">
                           <PaletteIcon type={componentData.paletteIconType || componentData.type} />


### PR DESCRIPTION
## Summary
- make component palette items draggable
- handle drop events in `CircuitCanvas`
- allow dropping components onto the canvas in project pages
- document the new library flyout

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cb464b864832794f44245ea651342