### PR TITLE
Update installation component skins

### DIFF
--- a/src/components/circuit/PaletteIcon.tsx
+++ b/src/components/circuit/PaletteIcon.tsx
@@ -91,21 +91,20 @@ const PaletteIcon: React.FC<PaletteIconProps> = ({ type }) => {
     // Installation specific icons
     case 'Abzweigdose':
       iconContent = (
-        <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
+        <rect x="6" y="6" width="28" height="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" strokeDasharray="4 2" />
       );
       break;
     case 'AbzweigdoseRect':
       iconContent = (
-        <rect x="6" y="10" width="28" height="20" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+        <rect x="6" y="10" width="28" height="20" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" strokeDasharray="4 2" />
       );
       break;
     case 'SchliesserInstallation':
       iconContent = (
         <>
-          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
-          {/* Simplified NO contact symbol inside */}
-          <line x1="20" y1="8" x2="20" y2="18" stroke={symbolStrokeColor} strokeWidth="2" />
-          <line x1="20" y1="22" x2="20" y2="32" stroke={symbolStrokeColor} strokeWidth="2" />
+          <rect x="6" y="6" width="28" height="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+          <line x1="20" y1="12" x2="20" y2="18" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="20" y1="22" x2="20" y2="28" stroke={symbolStrokeColor} strokeWidth="2" />
           <line x1="15" y1="18" x2="20" y2="22" stroke={symbolStrokeColor} strokeWidth="2" />
         </>
       );
@@ -113,28 +112,41 @@ const PaletteIcon: React.FC<PaletteIconProps> = ({ type }) => {
     case 'LampeInstallation':
        iconContent = (
         <>
-          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
-          <line x1="10" y1="10" x2="30" y2="30" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} />
-          <line x1="10" y1="30" x2="30" y2="10" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} />
+          <rect x="6" y="6" width="28" height="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+          <circle cx="20" cy="20" r="10" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
+          <line x1="12" y1="12" x2="28" y2="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} />
+          <line x1="12" y1="28" x2="28" y2="12" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} />
         </>
       );
       break;
     case 'Steckdose':
       iconContent = (
         <>
-          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
-          <circle cx="14" cy="16" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
-          <circle cx="26" cy="16" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
-          <circle cx="20" cy="24" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
+          <rect x="6" y="6" width="28" height="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+          <path d="M10 26 a10 10 0 0 1 20 0" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+          <line x1="18" y1="26" x2="18" y2="30" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="22" y1="26" x2="22" y2="30" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="20" y1="24" x2="20" y2="30" stroke={symbolStrokeColor} strokeWidth="2" />
         </>
       );
       break;
     case 'Wechselschalter':
       iconContent = (
         <>
-          <circle cx="20" cy="20" r="18" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill={symbolFillColor} />
-          <line x1="20" y1="8" x2="20" y2="20" stroke={symbolStrokeColor} strokeWidth="2" />
+          <rect x="6" y="6" width="28" height="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+          <line x1="20" y1="10" x2="20" y2="20" stroke={symbolStrokeColor} strokeWidth="2" />
           <line x1="12" y1="24" x2="28" y2="24" stroke={symbolStrokeColor} strokeWidth="2" />
+        </>
+      );
+      break;
+    case 'Ausschalter':
+      iconContent = (
+        <>
+          <rect x="6" y="6" width="28" height="28" stroke={symbolStrokeColor} strokeWidth={paletteStrokeWidth} fill="none" />
+          <circle cx="20" cy="9" r="3" stroke={symbolStrokeColor} strokeWidth="2" fill="none" />
+          <line x1="20" y1="12" x2="20" y2="18" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="20" y1="22" x2="20" y2="28" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="15" y1="18" x2="20" y2="22" stroke={symbolStrokeColor} strokeWidth="2" />
         </>
       );
       break;

--- a/src/config/component-definitions.tsx
+++ b/src/config/component-definitions.tsx
@@ -255,7 +255,7 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
     height: 40,
     render: (label) => (
       <>
-        <rect x="1" y="1" width="48" height="38" fill="transparent" stroke="black" strokeWidth="2" />
+        <rect x="1" y="1" width="48" height="38" fill="none" stroke="black" strokeDasharray="4 2" />
         <text x="25" y="-5" textAnchor="middle" className="component-text text-xs">{label}</text>
       </>
     ),
@@ -270,25 +270,48 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
     width: 30,
     height: 30,
     render: (label, _state, displayPinLabels = { 'L': 'L', 'Out': '' }, simulatedState) => {
-      const isClosed = simulatedState?.currentContactState?.L === 'closed'; // Assuming L is input and controls output
+      const isClosed = simulatedState?.currentContactState?.L === 'closed';
       return (
         <>
-          <circle cx="15" cy="15" r="14" className="symbol stroke-2" />
-          {/* Simplified NO contact symbol inside circle */}
+          <rect x="1" y="1" width="28" height="28" className="symbol stroke-2" fill="none" />
           <line x1="15" y1="5" x2="15" y2="12" className="line" strokeWidth="1.5" />
           <line x1="15" y1="18" x2="15" y2="25" className="line" strokeWidth="1.5" />
           {isClosed ? (
-             <line x1="15" y1="12" x2="15" y2="18" className="line stroke-[hsl(var(--destructive))]" strokeWidth="1.5"/>
+            <line x1="15" y1="12" x2="15" y2="18" className="line stroke-[hsl(var(--destructive))]" strokeWidth="1.5" />
           ) : (
-             <line x1="10" y1="12" x2="15" y2="18" className="line" strokeWidth="1.5"/>
+            <line x1="10" y1="12" x2="15" y2="18" className="line" strokeWidth="1.5" />
           )}
           <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
-           {/* Pin labels can be omitted for small symbols or placed outside if needed */}
         </>
       );
     },
     pins: {
-      // Pins typically at edges or center for connection routing
+      'L': { x: 15, y: 1, label: 'L' },
+      'Out': { x: 15, y: 29, label: 'Out' }
+    }
+  },
+
+  'Ausschalter': {
+    width: 30,
+    height: 30,
+    render: (label, _state, displayPinLabels = { 'L': 'L', 'Out': '' }, simulatedState) => {
+      const isClosed = simulatedState?.currentContactState?.L === 'closed';
+      return (
+        <>
+          <rect x="1" y="1" width="28" height="28" className="symbol stroke-2" fill="none" />
+          <circle cx="15" cy="4" r="2" className="line" fill="none" />
+          <line x1="15" y1="6" x2="15" y2="12" className="line" strokeWidth="1.5" />
+          <line x1="15" y1="18" x2="15" y2="25" className="line" strokeWidth="1.5" />
+          {isClosed ? (
+            <line x1="15" y1="12" x2="15" y2="18" className="line stroke-[hsl(var(--destructive))]" strokeWidth="1.5" />
+          ) : (
+            <line x1="10" y1="12" x2="15" y2="18" className="line" strokeWidth="1.5" />
+          )}
+          <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
+        </>
+      );
+    },
+    pins: {
       'L': { x: 15, y: 1, label: 'L' },
       'Out': { x: 15, y: 29, label: 'Out' }
     }
@@ -298,16 +321,16 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
     height: 30,
     render: (label, _state, _displayPinLabels, simulatedState) => (
       <>
+        <rect x="1" y="1" width="28" height="28" className="symbol stroke-2" fill="none" />
         <circle
           cx="15"
           cy="15"
-          r="14"
+          r="10"
           className="symbol stroke-2"
           style={{ fill: simulatedState?.isEnergized ? 'yellow' : 'hsl(var(--card))' }}
         />
-        {/* X inside circle */}
-        <line x1="8" y1="8" x2="22" y2="22" stroke="black" strokeWidth="1.5" fill="none" />
-        <line x1="8" y1="22" x2="22" y2="8" stroke="black" strokeWidth="1.5" fill="none" />
+        <line x1="9" y1="9" x2="21" y2="21" stroke="black" strokeWidth="1.5" fill="none" />
+        <line x1="9" y1="21" x2="21" y2="9" stroke="black" strokeWidth="1.5" fill="none" />
         <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
       </>
     ),
@@ -443,10 +466,11 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
     height: 30,
     render: (label) => (
       <>
-        <circle cx="15" cy="15" r="14" className="symbol stroke-2" />
-        <circle cx="11" cy="13" r="2" stroke="hsl(var(--foreground))" strokeWidth="1.5" fill="none" />
-        <circle cx="19" cy="13" r="2" stroke="hsl(var(--foreground))" strokeWidth="1.5" fill="none" />
-        <circle cx="15" cy="18" r="2" stroke="hsl(var(--foreground))" strokeWidth="1.5" fill="none" />
+        <rect x="1" y="1" width="28" height="28" className="symbol stroke-2" fill="none" />
+        <path d="M5 20 a10 10 0 0 1 20 0" className="line" />
+        <line x1="12" y1="20" x2="12" y2="24" className="line" />
+        <line x1="18" y1="20" x2="18" y2="24" className="line" />
+        <line x1="15" y1="22" x2="15" y2="26" className="line" />
         <text x="15" y="38" textAnchor="middle" className="component-text text-xs">{label}</text>
       </>
     ),
@@ -465,7 +489,7 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
       const inactiveX = toAusgang1 ? 22 : 8;
       return (
         <>
-          <circle cx="15" cy="15" r="14" className="symbol stroke-2" />
+          <rect x="1" y="1" width="28" height="28" className="symbol stroke-2" fill="none" />
           <line x1="15" y1="5" x2="15" y2="15" className="line" strokeWidth="1.5" />
           <line x1="8" y1="22" x2="8" y2="25" className="line" strokeWidth="1.5" />
           <line x1="22" y1="22" x2="22" y2="25" className="line" strokeWidth="1.5" />

--- a/src/config/mock-palette-data.ts
+++ b/src/config/mock-palette-data.ts
@@ -469,6 +469,29 @@ export const MOCK_PALETTE_COMPONENTS: PaletteComponentFirebaseData[] = [
     }
   },
   {
+    id: 'ausschalter_install',
+    name: 'Ausschalter',
+    type: 'Ausschalter',
+    abbreviation: 'A',
+    defaultLabelPrefix: 'A',
+    category: 'Installationselemente',
+    description: 'Einpoliger Ausschalter mit Rastmechanik.',
+    hasToggleState: true,
+    hasEditablePins: false,
+    initialPinLabels: { 'L': 'L', 'Out': 'Out' },
+    resizable: true,
+    defaultSize: { width: COMPONENT_DEFINITIONS['Ausschalter']?.width || 30, height: COMPONENT_DEFINITIONS['Ausschalter']?.height || 30 },
+    minScale: 0.8, maxScale: 1.5, scaleStep: 0.1,
+    simulation: {
+      interactable: true,
+      controlLogic: 'toggle_on_click',
+      controlledBy: 'user',
+      initialContactState: { 'L': 'open', 'Out': 'open' },
+      outputPinStateOnEnergized: { 'L': 'closed', 'Out': 'closed' },
+      outputPinStateOnDeEnergized: { 'L': 'open', 'Out': 'open' },
+    }
+  },
+  {
     id: 'lampe_install',
     name: 'Leuchte (Installation)',
     type: 'LampeInstallation',


### PR DESCRIPTION
## Summary
- adjust installation symbols to standard skins
- add new `Ausschalter` component
- show dashed junction boxes
- revise palette icons accordingly

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cb446f17c832788cb9fbe67947220