### PR TITLE
Fix double toggling of switch

### DIFF
--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -422,10 +422,14 @@ const DesignerPageContent: React.FC = () => {
 
   const handleComponentMouseUpInSim = useCallback(() => {
     if (pressedComponentId) {
-      toggleComponentState(pressedComponentId);
+      const comp = components.find(c => c.id === pressedComponentId);
+      const simConfig = getPaletteComponentById(comp?.firebaseComponentId)?.simulation;
+      if (simConfig?.controlLogic === 'toggle_on_press') {
+        toggleComponentState(pressedComponentId);
+      }
       setPressedComponentId(null);
     }
-  }, [pressedComponentId, toggleComponentState]);
+  }, [pressedComponentId, toggleComponentState, components]);
 
 
 const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) => {
@@ -757,7 +761,11 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
 
   const handleComponentClick = useCallback((id: string, isDoubleClick = false, clickCoords?: Point) => {
     if (isSimulating) {
-      toggleComponentState(id);
+      const comp = components.find(c => c.id === id);
+      const simConfig = getPaletteComponentById(comp?.firebaseComponentId)?.simulation;
+      if (simConfig?.controlLogic === 'toggle_on_click') {
+        toggleComponentState(id);
+      }
       return;
     }
 
@@ -841,8 +849,13 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
   }, [isSimulating, isMeasuring, getAbsolutePinCoordinates, connectionVoltages]);
 
   const handleComponentMouseDownInSim = (id: string) => {
-    setPressedComponentId(id);
-    toggleComponentState(id);
+    const comp = components.find(c => c.id === id);
+    const simConfig = getPaletteComponentById(comp?.firebaseComponentId)?.simulation;
+    if (!simConfig?.interactable) return;
+    if (simConfig.controlLogic === 'toggle_on_press') {
+      setPressedComponentId(id);
+      toggleComponentState(id);
+    }
   };
 
   const handleSaveComponentChanges = useCallback((id: string, newLabel: string, newPinLabels: Record<string, string>) => {

--- a/src/components/circuit/DraggableComponent.tsx
+++ b/src/components/circuit/DraggableComponent.tsx
@@ -84,7 +84,7 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({
   return (
     <g
       transform={`translate(${component.x}, ${component.y}) scale(${scale})`}
-      onMouseDown={isSimulating ? undefined : handleComponentMouseDown}
+      onMouseDown={handleComponentMouseDown}
       onMouseUp={isSimulating ? undefined : handleComponentMouseUp}
       onClick={handleComponentClick}
       onDoubleClick={isSimulating ? undefined : handleComponentDoubleClick}


### PR DESCRIPTION
## Summary
- ensure circuit component interactions only toggle once
- call pressed toggle logic based on control logic
- always register mouse down handler for components

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687ccb801db48327b56c2adb0ccb895b