### PR TITLE
Add relay contact highlighting

### DIFF
--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -40,6 +40,7 @@ const DesignerPageContent: React.FC = () => {
 
   // States for group selection
   const [selectedComponentIds, setSelectedComponentIds] = useState<string[]>([]);
+  const [highlightedComponentIds, setHighlightedComponentIds] = useState<string[]>([]);
   const [isSelecting, setIsSelecting] = useState(false);
   const [selectionStart, setSelectionStart] = useState<Point | null>(null);
   const [selectionRect, setSelectionRect] = useState<{x:number; y:number; width:number; height:number} | null>(null);
@@ -642,6 +643,21 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
     };
   }, []);
 
+  useEffect(() => {
+    if (selectedComponentIds.length === 0) {
+      setHighlightedComponentIds([]);
+      return;
+    }
+    const first = components.find(c => c.id === selectedComponentIds[0]);
+    if (!first) {
+      setHighlightedComponentIds([]);
+      return;
+    }
+    const label = first.label;
+    const matches = components.filter(c => c.label === label).map(c => c.id);
+    setHighlightedComponentIds(matches);
+  }, [selectedComponentIds, components]);
+
   const toggleSimulation = useCallback(() => {
     setIsSimulating(prev => {
       let newSimulatingState = !prev;
@@ -1128,6 +1144,7 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
             snapLines={snapLines}
             selectionRect={selectionRect}
             selectedComponentIds={selectedComponentIds}
+            highlightedComponentIds={highlightedComponentIds}
             onDropComponent={addComponentAtPosition}
           />
         </div>

--- a/src/components/canvas/CircuitCanvas.tsx
+++ b/src/components/canvas/CircuitCanvas.tsx
@@ -34,6 +34,7 @@ interface CircuitCanvasProps {
   onDropComponent?: (component: PaletteComponentFirebaseData, position: Point) => void;
   selectionRect?: { x: number; y: number; width: number; height: number } | null;
   selectedComponentIds?: string[];
+  highlightedComponentIds?: string[];
 }
 
 const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
@@ -66,7 +67,8 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
   onCanvasMouseDown,
   onDropComponent,
   selectionRect,
-  selectedComponentIds
+  selectedComponentIds,
+  highlightedComponentIds
 }) => {
 
   const viewData = projectType
@@ -168,6 +170,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
           isMeasuring={isMeasuring}
           simulatedState={simulatedComponentStates[comp.id]}
           selected={selectedComponentIds?.includes(comp.id)}
+          highlighted={highlightedComponentIds?.includes(comp.id)}
         />
       ))}
 

--- a/src/components/circuit/DraggableComponent.tsx
+++ b/src/components/circuit/DraggableComponent.tsx
@@ -14,6 +14,7 @@ interface DraggableComponentProps {
   isMeasuring?: boolean;
   simulatedState?: SimulatedComponentState;
   selected?: boolean;
+  highlighted?: boolean;
 }
 
 const DraggableComponent: React.FC<DraggableComponentProps> = ({
@@ -27,6 +28,7 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({
   isMeasuring,
   simulatedState,
   selected,
+  highlighted,
 }) => {
   const definition = COMPONENT_DEFINITIONS[component.type];
   if (!definition) return null;
@@ -110,6 +112,18 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({
           fill="none"
           stroke="hsl(var(--ring))"
           strokeDasharray="4 2"
+          pointerEvents="none"
+        />
+      )}
+      {!selected && highlighted && (
+        <rect
+          x={0}
+          y={0}
+          width={width}
+          height={height}
+          fill="none"
+          stroke="hsl(var(--ring))"
+          strokeDasharray="2 2"
           pointerEvents="none"
         />
       )}


### PR DESCRIPTION
## Summary
- highlight all components sharing a label when one is selected
- show dashed outline on highlighted components

## Testing
- `npm run build`
- `npx tsc --noEmit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ccbafe0408327a37978b69c169a00