### PR TITLE
Add ESC cancel and multi-delete

### DIFF
--- a/docs/codex/codex-tasks-juli.md
+++ b/docs/codex/codex-tasks-juli.md
@@ -46,8 +46,8 @@ angelegt werden.
 
 ### 4. **Tastenkürzel & Mehrfachbearbeitung**
 
-- [ ] **ESC** → laufenden Pin-Vorgang abbrechen
-- [ ] **DEL** → löscht **alle markierten Bauteile gleichzeitig**
+- [x] **ESC** → laufenden Pin-Vorgang abbrechen
+- [x] **DEL** → löscht **alle markierten Bauteile gleichzeitig**
 
 ---
 

--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -624,6 +624,32 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
   }, [handleMouseMove, handleMouseUpGlobal]);
 
   useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (connectingPin) {
+          setConnectingPin(null);
+        }
+      }
+      if (e.key === 'Delete') {
+        if (selectedComponentIds.length > 0 && !isSimulating) {
+          setComponents(prev => prev.filter(c => !selectedComponentIds.includes(c.id)));
+          setConnections(prev => prev.filter(conn => !selectedComponentIds.includes(conn.startComponentId) && !selectedComponentIds.includes(conn.endComponentId)));
+          if (selectedComponentForSidebar && selectedComponentIds.includes(selectedComponentForSidebar.id)) {
+            setSelectedComponentForSidebar(null);
+            setIsPropertiesSidebarOpen(false);
+          }
+          toast({ title: 'Bauteile gelöscht', description: `${selectedComponentIds.length} Bauteil${selectedComponentIds.length > 1 ? 'e' : ''} entfernt.` });
+          setSelectedComponentIds([]);
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [connectingPin, selectedComponentIds, isSimulating, selectedComponentForSidebar, toast]);
+
+  useEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {
       for (let entry of entries) {
         const { width, height } = entry.contentRect;


### PR DESCRIPTION
## Summary
- allow aborting ongoing pin connections with ESC
- allow deleting multiple selected components via Delete key
- mark hotkey tasks as completed in docs

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ccbda06e883278737bc3ae91073d9