### PR TITLE
Add Energieversorgung400V component

### DIFF
--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -75,8 +75,6 @@ const DesignerPageContent: React.FC = () => {
   const [isMeasuring, setIsMeasuring] = useState(false);
   const [measurements, setMeasurements] = useState<{id: number, x: number, y: number, value: string}[]>([]);
   const [showGrid, setShowGrid] = useState(false);
-  const [lineLength, setLineLength] = useState(300);
-  const [draggingLine, setDraggingLine] = useState<number | null>(null);
   const [simulationErrors, setSimulationErrors] = useState<string[]>([]);
 
   const filteredPaletteComponents = React.useMemo(() => {
@@ -96,7 +94,8 @@ const DesignerPageContent: React.FC = () => {
           'taster_schliesser_install',
           'lampe_install',
           'steckdose_install',
-          'schuetzspule'
+          'schuetzspule',
+          'netzeinspeisung_400v'
         ];
         return allowed.includes(comp.id);
       }
@@ -471,10 +470,6 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
       setDraggingWaypoint({connectionId, waypointIndex});
   }, [isSimulating]);
 
-  const handleLineHandleMouseDown = useCallback((index: number) => {
-      if (isSimulating) return;
-      setDraggingLine(index);
-  }, [isSimulating]);
 
   const handleCanvasMouseDown = (e: React.MouseEvent<SVGSVGElement>) => {
     if (isSimulating) return;
@@ -582,16 +577,10 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
         })
       );
       setSnapLines({ x: null, y: null });
-    } else if (draggingLine !== null) {
-      const newLen = Math.max(
-        50,
-        Math.min(viewBoxSize.width - 20, 2 * (x - viewBoxSize.width / 2))
-      );
-      setLineLength(newLen);
     } else {
       setSnapLines({ x: null, y: null });
     }
-  }, [draggingComponentId, offset, isSimulating, draggingWaypoint, components, isSelecting, selectionStart, draggingLine, viewBoxSize]);
+  }, [draggingComponentId, offset, isSimulating, draggingWaypoint, components, isSelecting, selectionStart, viewBoxSize]);
 
   const handleMouseUpGlobal = useCallback(() => {
     if (isSimulating) {
@@ -620,7 +609,6 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
     setSelectionRect(null);
     setDraggingComponentId(null);
     setDraggingWaypoint(null);
-    setDraggingLine(null);
     setSnapLines({ x: null, y: null });
   }, [isSimulating, handleComponentMouseUpInSim, isSelecting, selectionRect, components]);
 
@@ -1149,9 +1137,6 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
                 <Button variant="outline" size="sm" onClick={zoomOut}>
                     <ZoomOut className="mr-2 h-4 w-4" />
                 </Button>
-                <div className="flex items-center gap-1">
-                    <Input type="number" value={lineLength} onChange={(e) => setLineLength(Number(e.target.value))} className="w-20" />
-                </div>
                 <Button variant="outline" size="sm" onClick={() => setShowGrid(p => !p)}>
                     <Grid className="mr-2 h-4 w-4" /> {showGrid ? 'Raster ausblenden' : 'Raster aktivieren'}
                 </Button>
@@ -1184,8 +1169,6 @@ const handleMouseDownComponent = (e: React.MouseEvent<SVGGElement>, id: string) 
             selectedConnectionId={selectedConnectionId}
             projectType={projectType}
             showGrid={showGrid}
-            lineLength={lineLength}
-            onLineHandleMouseDown={handleLineHandleMouseDown}
             snapLines={snapLines}
             selectionRect={selectionRect}
             selectedComponentIds={selectedComponentIds}

--- a/src/components/canvas/CircuitCanvas.tsx
+++ b/src/components/canvas/CircuitCanvas.tsx
@@ -27,8 +27,6 @@ interface CircuitCanvasProps {
   selectedConnectionId?: string | null;
   projectType?: ProjectType | null;
   showGrid?: boolean;
-  lineLength?: number;
-  onLineHandleMouseDown?: (index: number) => void;
   snapLines?: { x: number | null; y: number | null };
   onCanvasMouseDown?: (e: React.MouseEvent<SVGSVGElement>) => void;
   onDropComponent?: (component: PaletteComponentFirebaseData, position: Point) => void;
@@ -61,8 +59,6 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
   selectedConnectionId,
   projectType,
   showGrid,
-  lineLength = 300,
-  onLineHandleMouseDown,
   snapLines,
   onCanvasMouseDown,
   onDropComponent,
@@ -139,69 +135,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = ({
       )}
       {showGrid && <rect width="100%" height="100%" fill="url(#a4grid)" />}
 
-      {projectType === 'Stromlaufplan in zusammenhängender Darstellung' && (
-        <g>
-          <defs>
-            <linearGradient id="pe-gradient" x1="0" x2="0" y1="0" y2="1">
-              <stop offset="0%" stopColor="#00FF00" />
-              <stop offset="50%" stopColor="#00FF00" />
-              <stop offset="50%" stopColor="#FFFF00" />
-              <stop offset="100%" stopColor="#FFFF00" />
-            </linearGradient>
-          </defs>
-          {/** Horizontal main rails */}
-          <line
-            x1={viewBoxWidth / 2 - lineLength / 2}
-            y1={10}
-            x2={viewBoxWidth / 2 + lineLength / 2}
-            y2={10}
-            stroke="#FF0000"
-            strokeWidth={2}
-          />
-          <line
-            x1={viewBoxWidth / 2 - lineLength / 2}
-            y1={20}
-            x2={viewBoxWidth / 2 + lineLength / 2}
-            y2={20}
-            stroke="#0000FF"
-            strokeWidth={2}
-          />
-          <line
-            x1={viewBoxWidth / 2 - lineLength / 2}
-            y1={30}
-            x2={viewBoxWidth / 2 + lineLength / 2}
-            y2={30}
-            stroke="url(#pe-gradient)"
-            strokeWidth={2}
-          />
-          <circle
-            cx={viewBoxWidth / 2 + lineLength / 2}
-            cy={10}
-            r={4}
-            fill="#FF0000"
-            onMouseDown={() => onLineHandleMouseDown?.(0)}
-            style={{ cursor: 'ew-resize' }}
-          />
-          <circle
-            cx={viewBoxWidth / 2 + lineLength / 2}
-            cy={20}
-            r={4}
-            fill="#0000FF"
-            onMouseDown={() => onLineHandleMouseDown?.(1)}
-            style={{ cursor: 'ew-resize' }}
-          />
-          <circle
-            cx={viewBoxWidth / 2 + lineLength / 2}
-            cy={30}
-            r={4}
-            fill="#FFFF00"
-            stroke="#00FF00"
-            strokeWidth={1}
-            onMouseDown={() => onLineHandleMouseDown?.(2)}
-            style={{ cursor: 'ew-resize' }}
-          />
-        </g>
-      )}
+
       {viewComponents.map(comp => (
         <DraggableComponent
           key={comp.id}

--- a/src/components/circuit/PaletteIcon.tsx
+++ b/src/components/circuit/PaletteIcon.tsx
@@ -161,6 +161,17 @@ const PaletteIcon: React.FC<PaletteIconProps> = ({ type }) => {
         </>
       );
       break;
+    case 'Energieversorgung400V':
+      iconContent = (
+        <>
+          <line x1="5" y1="8" x2="35" y2="8" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="5" y1="16" x2="35" y2="16" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="5" y1="24" x2="35" y2="24" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="5" y1="32" x2="35" y2="32" stroke={symbolStrokeColor} strokeWidth="2" />
+          <line x1="5" y1="38" x2="35" y2="38" stroke={symbolStrokeColor} strokeWidth="2" />
+        </>
+      );
+      break;
     default:
       iconContent = (
         <rect x="5" y="5" width="30" height="30" stroke="grey" strokeWidth="1" fill="lightgrey" />

--- a/src/components/svg/bauteile/energieversorgung/Energieversorgung400V.tsx
+++ b/src/components/svg/bauteile/energieversorgung/Energieversorgung400V.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+const Energieversorgung400V: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="260" height="240" viewBox="0 0 260 240" {...props}>
+    <g id="Energieversorgung400V">
+      <text x="0" y="20" fontSize="14" fontFamily="Arial">L1</text>
+      <line x1="30" y1="20" x2="240" y2="20" stroke="red" strokeWidth="3" />
+      <circle cx="240" cy="20" r="5" fill="white" stroke="black" strokeWidth="2" />
+
+      <text x="0" y="60" fontSize="14" fontFamily="Arial">L2</text>
+      <line x1="30" y1="60" x2="240" y2="60" stroke="black" strokeWidth="3" />
+      <circle cx="240" cy="60" r="5" fill="white" stroke="black" strokeWidth="2" />
+
+      <text x="0" y="100" fontSize="14" fontFamily="Arial">L3</text>
+      <line x1="30" y1="100" x2="240" y2="100" stroke="blue" strokeWidth="3" />
+      <circle cx="240" cy="100" r="5" fill="white" stroke="black" strokeWidth="2" />
+
+      <text x="0" y="140" fontSize="14" fontFamily="Arial">N</text>
+      <line x1="30" y1="140" x2="240" y2="140" stroke="blue" strokeDasharray="6,4" strokeWidth="2" />
+      <circle cx="240" cy="140" r="5" fill="white" stroke="black" strokeWidth="2" />
+
+      <text x="0" y="180" fontSize="14" fontFamily="Arial">PE</text>
+      <line x1="30" y1="180" x2="240" y2="180" stroke="green" strokeWidth="3" />
+      <circle cx="240" cy="180" r="5" fill="white" stroke="black" strokeWidth="2" />
+    </g>
+  </svg>
+);
+
+export default Energieversorgung400V;

--- a/src/config/component-definitions.tsx
+++ b/src/config/component-definitions.tsx
@@ -1,6 +1,7 @@
 // Using .tsx because it contains JSX in render functions
 import type { ComponentDefinition, SimulatedComponentState } from '@/types/circuit';
 import AusschalterSvg from '@/components/svg/Ausschalter';
+import Energieversorgung400VSvg from '@/components/svg/bauteile/energieversorgung/Energieversorgung400V';
 
 export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
   '24V': {
@@ -72,6 +73,22 @@ export const COMPONENT_DEFINITIONS: Record<string, ComponentDefinition> = {
         <text x="-20" y="12" className="component-text">{label}</text>
       </>
     ),
+  },
+  'Energieversorgung400V': {
+    width: 260,
+    height: 240,
+    render: (_label, _state, _displayPinLabels, _simulatedState, componentId) => (
+      <>
+        <Energieversorgung400VSvg data-component-id={componentId} />
+      </>
+    ),
+    pins: {
+      'L1': { x: 240, y: 20, label: 'L1' },
+      'L2': { x: 240, y: 60, label: 'L2' },
+      'L3': { x: 240, y: 100, label: 'L3' },
+      'N': { x: 240, y: 140, label: 'N' },
+      'PE': { x: 240, y: 180, label: 'PE' },
+    }
   },
   'Schließer': {
     width: 80,

--- a/src/config/mock-palette-data.ts
+++ b/src/config/mock-palette-data.ts
@@ -140,6 +140,25 @@ export const MOCK_PALETTE_COMPONENTS: PaletteComponentFirebaseData[] = [
     simulation: {
       interactable: false,
       controlLogic: 'pass_through',
+    controlledBy: 'voltage',
+  }
+  },
+  {
+    id: 'netzeinspeisung_400v',
+    name: 'Netzeinspeisung 400V (L1–L3, N, PE)',
+    type: 'Energieversorgung400V',
+    abbreviation: '400V',
+    defaultLabelPrefix: 'EV',
+    category: 'Energieversorgung',
+    description: 'Fügt die fünf horizontalen Hauptversorgungsleitungen als Stromlaufplan-Bauteil hinzu',
+    hasToggleState: false,
+    hasEditablePins: false,
+    initialPinLabels: { 'L1': 'L1', 'L2': 'L2', 'L3': 'L3', 'N': 'N', 'PE': 'PE' },
+    resizable: false,
+    defaultSize: { width: COMPONENT_DEFINITIONS['Energieversorgung400V'].width, height: COMPONENT_DEFINITIONS['Energieversorgung400V'].height },
+    simulation: {
+      interactable: false,
+      controlLogic: 'pass_through',
       controlledBy: 'voltage',
     }
   },


### PR DESCRIPTION
## Summary
- implement Energieversorgung400V SVG component
- register component in definitions and palette data
- add menu entry for Stromlaufplan allowed list
- remove default mini-rails from CircuitCanvas and related state
- update palette icon set with new icon

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d3656ebe08327a6c902ba7d9d1c79